### PR TITLE
Add syntax highlighting for API Blueprint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gem 'jekyll'
 gem 'jekyll-redirect-from'
-gem 'rouge'
+gem 'rouge', :git => 'https://github.com/kylef/rouge', :branch => 'kylef/apiblueprint-lexer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/kylef/rouge
+  revision: 7380391df32f3e040ace9bc8633ebb2d4636a4fb
+  branch: kylef/apiblueprint-lexer
+  specs:
+    rouge (1.8.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -57,7 +64,6 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     redcarpet (3.2.0)
-    rouge (1.7.4)
     safe_yaml (1.0.4)
     sass (3.4.6)
     timers (4.0.1)
@@ -72,4 +78,4 @@ PLATFORMS
 DEPENDENCIES
   jekyll
   jekyll-redirect-from
-  rouge
+  rouge!

--- a/_posts/2013-03-12-New-API-Blueprint-Format-Roll-Out.md
+++ b/_posts/2013-03-12-New-API-Blueprint-Format-Roll-Out.md
@@ -16,12 +16,14 @@ First I would like to thank our awesome users who contributed to the New Format 
 
 In the process we have made quite a few changes to the Format. For example, to improve both readability and the process of writing we have decided to leave the "header marks (#) forest" in favor of utilizing "much cleaner" Markdown lists, like so: 
 
-	# GET /message_of_the_day
-	Retrieves message of the day.
-	
-	+ Response 200 (application/json)
-			
-		{ "message" : "Hello World" }
+```apib
+# GET /message_of_the_day
+Retrieves message of the day.
+
++ Response 200 (application/json)
+
+        { "message" : "Hello World" }
+```
 
 You can find the New Format's [specification](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md) its [repository](https://github.com/apiaryio/api-blueprint). The specification is completely open-sourced and it is also accompanied by a [tutorial](https://github.com/apiaryio/api-blueprint/blob/master/examples/1.%20Simplest%20API.md) and examples.
 

--- a/_posts/2014-03-06-Surfing-API.md
+++ b/_posts/2014-03-06-Surfing-API.md
@@ -52,34 +52,37 @@ The example server is written in Ruby using [Sinatra][] and [Roar][] to better d
 
 Let's look at the `Folder` resource - a data model as used in backend, perhaps coming from a database: 
 
-
-    class Folder
-      attr_accessor :id
-      attr_accessor :name
-      attr_accessor :description
-      attr_accessor :parent
-      attr_accessor :meta
-    end
-
+```ruby
+class Folder
+  attr_accessor :id
+  attr_accessor :name
+  attr_accessor :description
+  attr_accessor :parent
+  attr_accessor :meta
+end
+```
 
 In REST we do not send the resources around as they are. Instead we interact with their *representations*. With [Roar][] I can easily create a resource representation using the appropriate representer, specifying what attributes to represent:
 
+```ruby
+module FolderJSONRepresentation
+  include Roar::Representer::JSON
 
-    module FolderJSONRepresentation
-      include Roar::Representer::JSON
-
-      property :id
-      property :name
-      property :description
-      property :parent
-      property :meta
-    end
+  property :id
+  property :name
+  property :description
+  property :parent
+  property :meta
+end
+```
 
 and then apply the representer on a resource:
 
-    folder = Folder.new
-    folder.extend(FolderJSONRepresentation)
-    folder.to_json  # returning JSON representation of Folder
+```ruby
+folder = Folder.new
+folder.extend(FolderJSONRepresentation)
+folder.to_json  # returning JSON representation of Folder
+```
 
 Similarly I can define and use the HAL or any other (e.g. XML) representation for the `Folder` resource. Following this pattern we can keep the backend data models free of any representation clutter and also radically simplify the API content negotiation.
 
@@ -95,39 +98,43 @@ Having my cake and eat it I will demonstrate using the API on this (slightly con
 
 How hard can this be using Ruby and [HyperResource](https://github.com/gamache/hyperresource)?
 
+```ruby
+api = HyperResource.new(root: 'http://mock-gtdtodoapi.apiary.io')
+api.folders.get.each do |f|
 
-    api = HyperResource.new(root: 'http://mock-gtdtodoapi.apiary.io')
-    api.folders.get.each do |f|
-      
-      folder = Folder.new
-      folder.extend(FolderHALRepresentation)
-      folder.from_hash(f.get.body)
+  folder = Folder.new
+  folder.extend(FolderHALRepresentation)
+  folder.from_hash(f.get.body)
 
-      puts "==> folder (#{f.id}):"
-      puts "  name: #{folder.name}"
-      puts "  description: #{folder.description}"
-      puts "  parent: #{folder.parent}"
-      puts "  meta: #{folder.meta}\n\n"
-    end 
+  puts "==> folder (#{f.id}):"
+  puts "  name: #{folder.name}"
+  puts "  description: #{folder.description}"
+  puts "  parent: #{folder.parent}"
+  puts "  meta: #{folder.meta}\n\n"
+end
+```
 
-
-What happens here? 
+What happens here?
 
 First I navigate to the root of GTD Todo API. In this case using the Apiary mock server: 
 
-    api = HyperResource.new(root: 'http://mock-gtdtodoapi.apiary.io')
-
+```ruby
+api = HyperResource.new(root: 'http://mock-gtdtodoapi.apiary.io')
+```
 
 Then I follow the `folders` link retrieving the `folders` resource HAL representation and iterate every embedded `folder` in it:
 
+```ruby
+api.folders.get.each do |f|
+```
 
-    api.folders.get.each do |f|
+Finally I will create an empty instance of the `Folder` resource (sharing the same data model with the server). Extend it with HAL Roar representer and fetch in the folder body following the `self` link of the embedded item:
 
-Finally I will create an empty instance of the `Folder` resource (sharing the same data model with the server). Extend it with HAL Roar representer and fetch in the folder body following the `self` link of the embedded item: 
-
-    folder = Folder.new
-    folder.extend(FolderHALRepresentation)
-    folder.from_hash(f.get.body)
+```ruby
+folder = Folder.new
+folder.extend(FolderHALRepresentation)
+folder.from_hash(f.get.body)
+```
 
 Voilà, here is one of the folders ready to print out!
 

--- a/_posts/2015-02-17-Utilising-API-Blueprint-in-API-Clients.md
+++ b/_posts/2015-02-17-Utilising-API-Blueprint-in-API-Clients.md
@@ -32,7 +32,7 @@ Once you’ve loaded your blueprint, you can retrieve the different resource act
 
 This example is going to make use of one of our example blueprints, “Polls API”. I’ve pulled out an excerpt of the example blueprint and it looks something like the following. Take a look at the [full version](http://docs.pollsapi.apiary.io/) ([source](https://github.com/apiaryio/api-blueprint/blob/be00b000e47561419f654374dd975a02083354e8/examples/Polls%20API.md)).
 
-```markdown
+```apib
 # Polls
 Polls is a simple web service that allows consumers to view polls and vote in them.
 


### PR DESCRIPTION
This pull request switches to a branch of mine for rouge which adds an API Blueprint lexer so we can have syntax highlighting for API Blueprint in our own blog (https://github.com/jneen/rouge/pull/261).

### Before

![screen shot 2015-05-06 at 13 42 54](https://cloud.githubusercontent.com/assets/44164/7493108/d4cd91d8-f3f5-11e4-915c-fa4f379c3a32.png)

### After

![screen shot 2015-05-06 at 13 42 27](https://cloud.githubusercontent.com/assets/44164/7493113/da4acf4a-f3f5-11e4-85a4-8fcb8b29af6d.png)